### PR TITLE
Update dependency versions in main and generated projects

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -11,7 +11,7 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,32}|(__.*__))$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 [MESSAGES CONTROL]
-disable = missing-docstring,  locally-disabled, too-few-public-methods, fixme, bad-continuation
+disable = missing-docstring,  locally-disabled, too-few-public-methods, fixme
 msg-template = {module}:{line} [{msg_id}: {symbol}] - {msg}
 
 [REPORTS]

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,15 @@ setup(
     install_requires=["cookiecutter>=1.4<2"],
     extras_require={
         "lint": [
-            "flake8<4",
-            "black==19.3b0",
+            "flake8<7",
+            "black<24",
             "pylint<3",
-            "mypy<0.800"
+            "mypy<2"
         ],
         "test": [
-            "pytest<5",
+            "pytest<8",
             "pytest-cookies<1",
-            "pytest-cov<3",
+            "pytest-cov<5",
         ],
     },
     zip_safe=False,

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -184,4 +184,4 @@ def test_build(cookies):
         check_output_in_result_dir("make build", result)
         with inside_directory_of(result):
             for pattern in EXPECTED_BUILD_PATTERNS:
-                assert glob.glob(pattern) != []
+                assert glob.glob(pattern)

--- a/tests/util.py
+++ b/tests/util.py
@@ -19,11 +19,9 @@ def generate_temporary_project(
 
 @contextlib.contextmanager
 def inside_directory_of(result: Any) -> Iterator[None]:
-    try:
-        old_dir = result.project.chdir()
-        yield
-    finally:
-        os.chdir(old_dir)
+    old_dir = result.project.chdir()
+    yield
+    os.chdir(old_dir)
 
 
 def check_output_in_result_dir(command: str, result: Any) -> str:

--- a/{{cookiecutter.package_name}}/pylintrc
+++ b/{{cookiecutter.package_name}}/pylintrc
@@ -11,7 +11,7 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,32}|(__.*__))$
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
 [MESSAGES CONTROL]
-disable = missing-docstring,  locally-disabled, too-few-public-methods, fixme, bad-continuation
+disable = missing-docstring,  locally-disabled, too-few-public-methods, fixme
 msg-template = {module}:{line} [{msg_id}: {symbol}] - {msg}
 
 [REPORTS]

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -22,8 +22,8 @@ setup(
     install_requires=[],
     extras_require={
         "build": ["wheel<1"],
-        "lint": ["flake8<4", "black==19.3b0"{%- if cookiecutter.use_pylint == "y" %}, "pylint<3"{%- endif%}{%- if cookiecutter.use_mypy == "y" %}, "mypy<0.800"{%- endif%}],
-        "test": ["pytest<5", "pytest-cov<3"],
+        "lint": ["flake8<7", "black<24"{%- if cookiecutter.use_pylint == "y" %}, "pylint<3"{%- endif%}{%- if cookiecutter.use_mypy == "y" %}, "mypy<2"{%- endif%}],
+        "test": ["pytest<8", "pytest-cov<5"],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
This has been done a few years ago, the last time, many of the tools have jumped multiple major versions.
Also update pylint configs and fix new errors.
